### PR TITLE
[WS-4802] Add proc support for mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,45 @@ Or install it yourself as:
 class AdpMapper
   include Dozer::Mapperable
 
-  mapping from: 'adp/firstName', to: :first_name
-  mapping from: 'adp/lastName',  to: :last_name
-  mapping from: 'adp/gender',    to: :gender
+  mapping from: 'adp/firstName',   to: :first_name
+  mapping from: 'adp/lastName',    to: :last_name
+  mapping from: 'adp/gender',      to: :gender
 end
 ```
- 
+
+How to transform the value when mapping? You can do it in two ways: proc or method.
+
+Usage example of Proc
+
+```
+class AdpMapper
+  include Dozer::Mapperable
+
+  mapping from: 'adp/gender',      to: :gender,    func: -> (value) { {male: 'M', female: 'F'}.fetch(value) } 
+  mapping from: 'marital_status',  to: :marriage, 
+  mapping from: 'adp/gender',      to: :gender
+end
+```
+
+Usage example of method
+
+```
+class AdpMapper
+  include Dozer::Mapperable
+
+  mapping from: 'gender',          to: :gender,    func: :gender_to_integer
+  mapping from: 'marital_status',  to: :marriage, 
+
+  def gender_to_integer(val)
+    new_value = {male: 1, female: 2}.fetch(val, nil)
+    new_value
+  end
+end
+```
+
+
+
+
 If you have multiple integrations, you can define a set of mapper classes in your Rails application folder.
 
 ```

--- a/lib/dozer.rb
+++ b/lib/dozer.rb
@@ -1,6 +1,7 @@
 require 'active_support'
 require 'active_support/core_ext/hash'
 require "dozer/version"
+require 'dozer/rule'
 require 'dozer/mapperable'
 
 module Dozer

--- a/lib/dozer/mapperable.rb
+++ b/lib/dozer/mapperable.rb
@@ -4,39 +4,36 @@ module Dozer
 
     module ClassMethods
       def mapping(options)
-        options = options.with_indifferent_access
-        raise ArgumentError, 'from is missing' if options[:from].nil?
-        raise ArgumentError, 'to is missing' if options[:to].nil?
-
-        dozer_forward_mapper[options[:from]] = options[:to].to_sym
-        dozer_backward_mapper[options[:to]] = options[:from].to_sym
+        rule = Dozer::Rule.new(options.merge(base_klass: self))
+        append_rule(rule)
       end
 
-      private def dozer_forward_mapper
-        @dozer_forward_mapper ||= {}.with_indifferent_access
-      end
-
-      private  def dozer_backward_mapper
-        @dozer_backward_mapper ||= {}.with_indifferent_access
-      end
-
-      def transform(hash, options={})
-        result = {}.with_indifferent_access
-
-        options = options.with_indifferent_access
-        mapper = if options[:reverse] == true
-                   dozer_backward_mapper
-                 else
-                   dozer_forward_mapper
-                 end
-
-        hash.each do |k, v|
-          new_key = mapper[k]
-          result[new_key] = v if new_key
+      def transform(input, options={})
+        input, output = input.with_indifferent_access, ActiveSupport::HashWithIndifferentAccess.new
+        kvs = all_rules.map { |rule| rule.apply(input) }.compact!
+        kvs.each do |kv|
+          key, value = kv.first, kv.last
+          output[key] = value
         end
 
-        result
+        output
       end
+
+      private
+
+      def append_rule(new_rule)
+        if all_rules.any? {|r| r.to == new_rule.to}
+          raise ArgumentError, "to: :#{new_rule.to} has been declared."
+        end
+
+        all_rules << new_rule
+      end
+
+
+      private def all_rules
+        @__all_rules ||= []
+      end
+
     end # end of ClassMethods
 
   end # end of Mapperable

--- a/lib/dozer/rule.rb
+++ b/lib/dozer/rule.rb
@@ -1,0 +1,46 @@
+module Dozer
+  class Rule
+    attr_accessor :base_klass, :from, :to, :func
+
+    def initialize(options)
+      options = options.with_indifferent_access
+      validate!(options)
+
+      @base_klass = options[:base_klass]
+      @from = options[:from].to_sym
+      @to   = options[:to].to_sym
+      @func = options[:func]
+    end
+
+    def apply(input)
+      if applicable?(input)
+        [to, evaluate(input[from])]
+      else
+        nil
+      end
+    end
+
+    private
+
+    def applicable?(input)
+      input.key?(from)
+    end
+
+    def evaluate(value)
+      return value if func.nil?
+      return func.call(value) if func.is_a?(Proc)
+      return base_klass.new.send(func, value) if func.is_a?(Symbol)
+      nil
+    end
+
+    def validate!(options)
+      raise ArgumentError, 'from is missing.' if options[:from].nil?
+      raise ArgumentError, 'to is missing.' if options[:to].nil?
+      if !(options[:func].nil? || options[:func].is_a?(Symbol) || options[:func].is_a?(Proc))
+        raise ArgumentError, 'func should be a symbol or proc.'
+      end
+      true
+    end
+
+  end # end of Rule
+end # end of Dozer

--- a/lib/dozer/version.rb
+++ b/lib/dozer/version.rb
@@ -1,3 +1,3 @@
 module Dozer
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/dozer_spec.rb
+++ b/spec/dozer_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Dozer do
     expect(Dozer::VERSION).not_to be nil
   end
 
-  it 'should successfull map data from one schema to another schema' do
+  it 'should successfully map data from one schema to another schema' do
     hash = { 'legal_first_name' => 'Ryan', legal_last_name: 'Lyu' }
     result = Dozer.map(hash, BarMapper)
 

--- a/spec/lib/dozer/rule_spec.rb
+++ b/spec/lib/dozer/rule_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+require 'date'
+
+RSpec.describe Dozer::Rule do
+  describe '#initialize' do
+    it 'should succeed' do
+      expect { Dozer::Rule.new(from: :firstName, to: :first_name) }.not_to raise_error
+      expect { Dozer::Rule.new(from: 'firstName', to: 'first_name') }.not_to raise_error
+      expect { Dozer::Rule.new('from' => 'firstName', 'to' => 'first_name') }.not_to raise_error
+      expect { Dozer::Rule.new('from' => :firstName, 'to' => :first_name) }.not_to raise_error
+      expect { Dozer::Rule.new(from: :firstName, to: :first_name, func: ->(val) { val.to_s }) }.not_to raise_error
+      expect { Dozer::Rule.new(from: :firstName, to: :first_name, func: :some_function) }.not_to raise_error
+    end
+
+    it 'should raise error' do
+      expect { Dozer::Rule.new(from: :firstName) }.to raise_error(ArgumentError)
+      expect { Dozer::Rule.new(to: :first_name) }.to raise_error(ArgumentError)
+      expect { Dozer::Rule.new(from: :firstName, to: :first_name, func: "something") }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#applicable?' do
+    it 'should be not applicable?' do
+      rule = Dozer::Rule.new(from: :firstName, to: :first_name)
+      input = {age: 32}
+      expect(rule.send(:applicable?, input)).to be false
+    end
+
+    it 'should be applicable?' do
+      rule = Dozer::Rule.new(from: :firstName, to: :first_name)
+      input = {firstName: 'Ryan'}
+      expect(rule.send(:applicable?, input)).to be true
+    end
+  end
+
+  describe '#evaluate' do
+    it 'should call a proc to convert a datetime to date' do
+      started_at = DateTime.parse('2020-08-06 11:37:25')
+      rule = Dozer::Rule.new(from: :started_at, to: :start_on, func: ->(datetime) { datetime.to_date.to_s })
+      started_on = rule.send(:evaluate, started_at)
+      expect(started_on).to eq('2020-08-06')
+    end
+
+    it 'should call a method to convert an string to string' do
+      class TestMapperWithMethod
+        include ::Dozer::Mapperable
+
+        def status_to_boolean(val)
+          case val
+          when 'true'
+            true
+          when 'false'
+            false
+          end
+        end
+      end
+
+      rule = Dozer::Rule.new(from: :status, to: :status, func: :status_to_boolean, base_klass: TestMapperWithMethod)
+      expect(rule.send(:evaluate, 'true')).to be true
+      expect(rule.send(:evaluate, 'false')).to be false
+    end
+  end
+end

--- a/spec/lib/dozer/test_mapper/adp_mapper.rb
+++ b/spec/lib/dozer/test_mapper/adp_mapper.rb
@@ -1,0 +1,20 @@
+class AdpMapper
+  include ::Dozer::Mapperable
+
+  mapping from: :first_name,          to: '/applicant/person/legalName/givenName'
+  mapping from: :last_name,           to: '/applicant/person/legalName/familyName1'
+  mapping from: :phone_country_code,  to: '/applicant/person/communication/mobiles/countryDialing'
+  mapping from: :phone_number,        to: '/applicant/person/communication/mobiles/dialNumber'
+  mapping from: :email,               to: '/applicant/person/communication/emails/emailUri'
+  mapping from: :birthday,            to: '/applicant/person/birthDate'
+  mapping from: :gender,              to: '/applicant/person/genderCode/codeValue', func: ->(val) { {male: 'M', female: 'F'}.fetch(val, nil) }
+  mapping from: :marital_status,     to: '/applicant/person/maritalStatusCode/codeValue', func: :transform_marital_status
+
+
+  def transform_marital_status(value)
+    return '1' if value == 'married'
+    return '2' if value == 'single'
+    return '3' if value == 'divorced'
+    'U'
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require "dozer"
 require 'pry'
 require 'lib/dozer/test_mapper/foo_mapper'
 require 'lib/dozer/test_mapper/bar_mapper'
+require 'lib/dozer/test_mapper/adp_mapper'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Usage example

```
class AdpMapper
  include ::Dozer::Mapperable

  mapping from: :first_name,          to: '/applicant/person/legalName/givenName'
  mapping from: :last_name,           to: '/applicant/person/legalName/familyName1'
  mapping from: :phone_country_code,  to: '/applicant/person/communication/mobiles/countryDialing'
  mapping from: :phone_number,        to: '/applicant/person/communication/mobiles/dialNumber'
  mapping from: :email,               to: '/applicant/person/communication/emails/emailUri'
  mapping from: :birthday,            to: '/applicant/person/birthDate'
  mapping from: :gender,              to: '/applicant/person/genderCode/codeValue', func: ->(val) { {male: 'M', female: 'F'}.fetch(val, nil) }
  mapping from: :marital_status,     to: '/applicant/person/maritalStatusCode/codeValue', func: :transform_marital_status


  def transform_marital_status(value)
    return '1' if value == 'married'
    return '2' if value == 'single'
    return '3' if value == 'divorced'
    'U'
  end
end

```