### PR TITLE
refactor code

### DIFF
--- a/lib/dozer.rb
+++ b/lib/dozer.rb
@@ -9,6 +9,6 @@ module Dozer
 
   # transform the data from one schema to another schema.
   def self.map(hash, mapper, options={})
-    mapper.transform(hash, options)
+    mapper.transform(hash)
   end
 end

--- a/lib/dozer/rule.rb
+++ b/lib/dozer/rule.rb
@@ -1,23 +1,29 @@
 module Dozer
   class Rule
-    attr_accessor :base_klass, :from, :to, :func
+    attr_accessor :from, :to, :func
 
     def initialize(options)
       options = options.with_indifferent_access
       validate!(options)
 
-      @base_klass = options[:base_klass]
       @from = options[:from].to_sym
       @to   = options[:to].to_sym
       @func = options[:func]
     end
 
-    def apply(input)
-      if applicable?(input)
-        [to, evaluate(input[from])]
-      else
-        nil
+    def apply!(instance)
+      return if !applicable?(instance.input)
+
+      value = case 
+      when func.nil?
+        instance.input[from]
+      when func.is_a?(Proc)
+        func.call(instance.input[from])
+      when func.is_a?(Symbol) && instance.respond_to?(func)
+        instance.send(func)
       end
+
+      instance.output[to] = value
     end
 
     private
@@ -26,12 +32,12 @@ module Dozer
       input.key?(from)
     end
 
-    def evaluate(value)
-      return value if func.nil?
-      return func.call(value) if func.is_a?(Proc)
-      return base_klass.new.send(func, value) if func.is_a?(Symbol)
-      nil
-    end
+    # def evaluate(value)
+    #   return value if func.nil?
+    #   return func.call(value) if func.is_a?(Proc)
+    #   return base_klass.new.send(func, value) if func.is_a?(Symbol)
+    #   nil
+    # end
 
     def validate!(options)
       raise ArgumentError, 'from is missing.' if options[:from].nil?

--- a/spec/lib/dozer/rule_spec.rb
+++ b/spec/lib/dozer/rule_spec.rb
@@ -33,31 +33,31 @@ RSpec.describe Dozer::Rule do
     end
   end
 
-  describe '#evaluate' do
-    it 'should call a proc to convert a datetime to date' do
-      started_at = DateTime.parse('2020-08-06 11:37:25')
-      rule = Dozer::Rule.new(from: :started_at, to: :start_on, func: ->(datetime) { datetime.to_date.to_s })
-      started_on = rule.send(:evaluate, started_at)
-      expect(started_on).to eq('2020-08-06')
-    end
+  # describe '#evaluate' do
+  #   it 'should call a proc to convert a datetime to date' do
+  #     started_at = DateTime.parse('2020-08-06 11:37:25')
+  #     rule = Dozer::Rule.new(from: :started_at, to: :start_on, func: ->(datetime) { datetime.to_date.to_s })
+  #     started_on = rule.send(:evaluate, started_at)
+  #     expect(started_on).to eq('2020-08-06')
+  #   end
 
-    it 'should call a method to convert an string to string' do
-      class TestMapperWithMethod
-        include ::Dozer::Mapperable
+  #   it 'should call a method to convert an string to string' do
+  #     class TestMapperWithMethod
+  #       include ::Dozer::Mapperable
 
-        def status_to_boolean(val)
-          case val
-          when 'true'
-            true
-          when 'false'
-            false
-          end
-        end
-      end
+  #       def status_to_boolean(val)
+  #         case val
+  #         when 'true'
+  #           true
+  #         when 'false'
+  #           false
+  #         end
+  #       end
+  #     end
 
-      rule = Dozer::Rule.new(from: :status, to: :status, func: :status_to_boolean, base_klass: TestMapperWithMethod)
-      expect(rule.send(:evaluate, 'true')).to be true
-      expect(rule.send(:evaluate, 'false')).to be false
-    end
-  end
+  #     rule = Dozer::Rule.new(from: :status, to: :status, func: :status_to_boolean, base_klass: TestMapperWithMethod)
+  #     expect(rule.send(:evaluate, 'true')).to be true
+  #     expect(rule.send(:evaluate, 'false')).to be false
+  #   end
+  # end
 end

--- a/spec/lib/dozer/test_mapper/adp_mapper.rb
+++ b/spec/lib/dozer/test_mapper/adp_mapper.rb
@@ -8,13 +8,13 @@ class AdpMapper
   mapping from: :email,               to: '/applicant/person/communication/emails/emailUri'
   mapping from: :birthday,            to: '/applicant/person/birthDate'
   mapping from: :gender,              to: '/applicant/person/genderCode/codeValue', func: ->(val) { {male: 'M', female: 'F'}.fetch(val, nil) }
-  mapping from: :marital_status,     to: '/applicant/person/maritalStatusCode/codeValue', func: :transform_marital_status
+  mapping from: :marital_status,      to: '/applicant/person/maritalStatusCode/codeValue', func: :transform_marital_status
 
 
-  def transform_marital_status(value)
-    return '1' if value == 'married'
-    return '2' if value == 'single'
-    return '3' if value == 'divorced'
+  def transform_marital_status
+    return '1' if @input[:marital_status] == 'married'
+    return '2' if @input[:marital_status] == 'single'
+    return '3' if @input[:marital_status] == 'divorced'
     'U'
   end
 end


### PR DESCRIPTION
Old way

```
class AdpMapper
  include ::Dozer::Mapperable

....
  def transform_marital_status(value)
    return '1' if value == 'married'
    return '2' if value == 'single'
    return '3' if value == 'divorced'
    'U'
  end
end
```

New Way

```
class AdpMapper
  include ::Dozer::Mapperable

....
  def transform_marital_status
    return '1' if @input[:marital_status] == 'married'
    return '2' if @input[:marital_status] == 'single'
    return '3' if @input[:marital_status] == 'divorced'
    'U'
  end
end
```


which way do you like?
